### PR TITLE
Fixed tests as loadTestsFromTestCase can produce multiple tests

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -120,8 +120,8 @@ def suite():
     # suite consists of any test* method defined in PuzzleTests, plus a round-trip
     # test for each .puz file in ./testfiles/
     suite = unittest.TestSuite()
-    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(PuzzleTests))
-    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(LockTests))
+    suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(PuzzleTests))
+    suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(LockTests))
     suite.addTests(tests_in_dir('testfiles'))
     #suite.addTests(tests_in_dir('../xwordapp/data/'))
 


### PR DESCRIPTION
The tests didn't run due to use of addTest instead of addTests.
