### PR TITLE
Add support for reading the .txt format useful for authoring crosswords.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,12 @@ Load a puzzle file::
   import puz
   p = puz.read('testfiles/washpost.puz')
 
+Create a puzzle in the txt format (http://www.litsoft.com/across/docs/AcrossTextFormat.pdf) and convert to .puz::
+
+  import puz
+  p = puz.read('testfiles/txt_puzzle.txt')
+  p.save('/tmp/txt_puzzle.puz')
+
 Print clues with answers::
 
   numbering = p.clue_numbering()

--- a/testfiles/txt_puzzle.txt
+++ b/testfiles/txt_puzzle.txt
@@ -1,0 +1,108 @@
+<ACROSS PUZZLE>
+<TITLE>
+	Politics: Who, what, where and why
+<AUTHOR>
+	Created by Avalonian
+<COPYRIGHT>
+	1995 Literate Software Systems
+<SIZE>
+	15x15
+<GRID>
+	FATE.AWASH.AWOL
+	LIES.CURIO.SHOE
+	ELECTORATE.SIZE
+	ASS.ERST.DIETED
+	...CENT.HOSTESS
+	REFITS.JEWISH..
+	ARITH.KERNS.OAF
+	NILE.ANNES.DUPE
+	DEI.OVENS.LOSER
+	..BODILY.RACERS
+	GLUTEAL.PEPS...
+	RESIST.SLUE.SKI
+	OTTO.REPUBLICAN
+	OMES.IRATE.RAMS
+	MERE.XENON.ABET
+<ACROSS>
+	Destiny
+	Above water, barely
+	Deserter
+	True ____ : Arnold S. movie
+	Novel or rare item
+	If the ____ fits, ...
+	Favorite group of 53 across
+	EEE with 16 across
+	Midsummer's Night Dream character
+	Formerly
+	Ate sparingly
+	Monetary unit
+	She entertains guests
+	Make ready for use again
+	Yiddish, informally
+	Math. subject
+	Parts of typeset characters
+	Clod
+	Egyptian river
+	Bancroft and Archer
+	Fool
+	God in latin
+	Pizza place fixtures
+	Sometimes a dieter is one
+	Physical
+	Some kinds of snakes
+	Of posterior muscles
+	Raises one's spirits
+	Block
+	Swing about
+	____ slopes
+	A dog's name
+	GOP member
+	Of masses
+	Angry
+	Strikes violently
+	Just
+	Inert gas
+	Encourage
+<DOWN>
+	Biting insect
+	Troubles
+	Golf equipments
+	Computer keyboard key
+	Oak seed or fruit
+	Sausage
+	I smell ____
+	Squat
+	Community dances
+	Owned property
+	House on Pennsylvania Ave.
+	Seeps
+	City NE of Manchester
+	Subject of dentistry
+	Wife of Asiris
+	Use reference
+	"____, Johnny!"
+	South African currency unit
+	Canal or Lake
+	Delaying tactic of 53 across
+	Spinning ____
+	Toll
+	One who mimics
+	Bearers : comb. form
+	Female pilot
+	Medics
+	Homages
+	Coat part
+	Idle
+	Type of sandwich
+	Clean and care for
+	"____ through!"
+	Smallest planet of the Sun
+	Cover
+	One who works despite a strike
+	Glacial ridge
+	Org.
+	Before
+	Tax break savings account
+<NOTEPAD>
+This is an example notepad entry with
+two lines in it.

--- a/tests.py
+++ b/tests.py
@@ -13,6 +13,11 @@ class PuzzleTests(unittest.TestCase):
         clues = p.clue_numbering()
         self.assertEqual(len(p.clues), len(clues.across) + len(clues.down))
 
+    def test_txt_format(self):
+        p = puz.read('testfiles/txt_puzzle.txt')
+        clues = p.clue_numbering()
+        self.assertEqual(len(p.clues), len(clues.across) + len(clues.down))
+
     def test_extensions(self):
         p = puz.read('testfiles/nyt_rebus_with_notes_and_shape.puz')
         # We don't use assertIn for compatibility with Python 2.6


### PR DESCRIPTION
The .txt format (http://www.litsoft.com/across/docs/AcrossTextFormat.pdf) offers a convenient
way to author a crossword puzzle using any text editor. With this commit, we can author a .txt
file and convert it to the .puz format easily, like this:
  import puz
  p = puz.read('puzzle.txt')
  p.save('puzzle.puz')