### PR TITLE
Fix "black" square check for diagramless puzzles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# pycharm project
+.idea/

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Games/Entertainment :: Puzzle Games',
     ],
     keywords='puz crosswords crossword puzzle acrosslite xword xwords'

--- a/tests.py
+++ b/tests.py
@@ -13,6 +13,11 @@ class PuzzleTests(unittest.TestCase):
         clues = p.clue_numbering()
         self.assertEqual(len(p.clues), len(clues.across) + len(clues.down))
 
+    def test_diagramless_clue_numbering(self):
+        p = puz.read('testfiles/nyt_diagramless.puz')
+        clues = p.clue_numbering()
+        self.assertEqual(len(p.clues), len(clues.across) + len(clues.down))
+
     def test_extensions(self):
         p = puz.read('testfiles/nyt_rebus_with_notes_and_shape.puz')
         # We don't use assertIn for compatibility with Python 2.6
@@ -80,16 +85,16 @@ class LockTests(unittest.TestCase):
         '''
         self.assertEqual('MLOOPKJ', puz.scramble_string('AEBFCDG', 1234))
         self.assertEqual('MOP..KLOJ',
-                         puz.scramble_solution('ABC..DEFG', 3, 3, 1234))
+                         puz.scramble_solution('ABC..DEFG', 3, 3, 1234, puz.PuzzleType.Normal))
 
         self.assertEqual('AEBFCDG', puz.unscramble_string('MLOOPKJ', 1234))
         self.assertEqual('ABC..DEFG',
-                         puz.unscramble_solution('MOP..KLOJ', 3, 3, 1234))
+                         puz.unscramble_solution('MOP..KLOJ', 3, 3, 1234, puz.PuzzleType.Normal))
 
         # rectangular example - tricky
         a = 'ABCD.EFGH.KHIJKLM.NOPW.XYZ'
-        scrambled = puz.scramble_solution(a, 13, 2, 9721)
-        unscrambled = puz.unscramble_solution(scrambled, 13, 2, 9721)
+        scrambled = puz.scramble_solution(a, 13, 2, 9721, puz.PuzzleType.Normal)
+        unscrambled = puz.unscramble_solution(scrambled, 13, 2, 9721, puz.PuzzleType.Normal)
         self.assertEqual(a, unscrambled)
 
     def test_locked_bit(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py26, py27, py32, py33, py34, py35, py36
+envlist = py26, py27, py32, py33, py34, py35, py36, py37
 
 [testenv]
 commands = python tests.py
 
-[testenv:py36]
+[testenv:py37]
 commands =
     coverage run tests.py
     coverage html


### PR DESCRIPTION
Diagramless puzzles use a different character to denote 'black" squares (':' instead of '.'). This caused issues w/ clue_numbering. I assume it would cause issues w/ scrambling as well, though I haven't looked into that. I've tried to construct the fix so as not to break anyone's usage of the current API. 