### PR TITLE
Add clue index for across/down mapping help

### DIFF
--- a/puz.py
+++ b/puz.py
@@ -481,6 +481,7 @@ class DefaultClueNumbering:
                     a.append({
                         'num': n,
                         'clue': clues[c],
+                        'clue_index': c,
                         'cell': i,
                         'len': self.len_across(i)
                     })
@@ -490,6 +491,7 @@ class DefaultClueNumbering:
                     d.append({
                         'num': n,
                         'clue': clues[c],
+                        'clue_index': c,
                         'cell': i,
                         'len': self.len_down(i)
                     })


### PR DESCRIPTION
This is to support tools that may want to manipulate clues based on
whether they are across or down.  I think this would be fairly complex
without this addition.  Maybe there's an easier way.

Here's how the addition here might be used:

```python
def convert_to_downs_only(p):
    for i in map(lambda c: c['clue_index'], p.clue_numbering().across):
        p.clues[i] = '-'

    #  clear any previous cached numbering
    p.helpers.pop('clues', None)
```