### PR TITLE
add python package release workflow

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -1,0 +1,48 @@
+﻿# This workflow builds the python dist and uploads to pypi in response to a release being published
+# For more information see: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+
+name: publish release
+
+on:
+  release:
+    types: [ released ]
+
+jobs:
+  build:
+    name: Build dist package
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+    - name: Install build
+      run: pip install build
+    - name: Build binary wheel and a source tarball
+      run: python -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: Publish python distribution to PyPI
+    runs-on: ubuntu-latest
+    needs:
+     - build
+    environment:
+      name: pypi
+      url: https://pypi.org/puzpy
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+    - name: Download dist package
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
create a github workflow to build the dist package when a release is published, and upload to pypi