### PR TITLE
allow serialized dicts to have ':' in values

### DIFF
--- a/puz.py
+++ b/puz.py
@@ -761,7 +761,7 @@ def pack_bytes(a):
 # dict string format is k1:v1;k2:v2;...;kn:vn;
 # (for whatever reason there's a trailing ';')
 def parse_dict(s):
-    return dict(p.split(':') for p in s.split(';') if ':' in p)
+    return dict(p.split(':', maxsplit=1) for p in s.split(';') if ':' in p)
 
 
 def dict_to_string(d):


### PR DESCRIPTION
While working on an xword-dl PR that replaced the ascii-fication library with a different one (anyascii), I noticed that it replaces certain characters with `:text:` representations. Obviously this is less than ideal, but I don't think having a colon character in a rebus answer should cause an exception in `puzpy`, and there's no reason for it to - if we limit the number of splits to 1.