### PR TITLE
mypy -> pyright; flake8 -> ruff; use uv in ci jobs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length=127

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,22 @@ jobs:
       run: uv sync --extra dev --python ${{ matrix.python-version }}
     - name: unit tests
       run: uv run pytest
-    - name: type check
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+    - name: Set up uv
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b #v8.1.0
+      with:
+        enable-cache: true
+    - name: Set up Python
+      run: uv python install 3.13
+    - name: Install dependencies
+      run: uv sync --extra dev --python 3.13
+    - name: ruff
+      run: uv run ruff check
+    - name: pyright
       run: uv run pyright
 
   coverage:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,17 +24,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
+    - name: Set up uv
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b #v8.1.0
       with:
-        python-version: ${{ matrix.python-version }}
-        cache: pip
+        enable-cache: true
+    - name: Set up Python ${{ matrix.python-version }}
+      run: uv python install ${{ matrix.python-version }}
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e ".[dev]"
+      run: uv sync --extra dev --python ${{ matrix.python-version }}
     - name: unit tests
-      run: pytest
+      run: uv run pytest
+    - name: type check
+      run: uv run pyright
 
   coverage:
     needs: run-tests
@@ -51,19 +52,18 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-    - name: Set up Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
+    - name: Set up uv
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b #v8.1.0
       with:
-        python-version: "3.13"
-        cache: pip
+        enable-cache: true
+    - name: Set up Python
+      run: uv python install 3.13
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e ".[dev]"
+      run: uv sync --extra dev --python 3.13
     - name: Run coverage
-      run: pytest --cov --cov-report=html:site/coverage --cov-report=json:site/coverage/coverage.json
+      run: uv run pytest --cov --cov-report=html:site/coverage --cov-report=json:site/coverage/coverage.json
     - name: Generate puzzle viewers
-      run: python puz_viewer.py testfiles/*.puz testfiles/*.txt --outdir site/viewer --index
+      run: uv run python puz_viewer.py testfiles/*.puz testfiles/*.txt --outdir site/viewer --index
     - name: Upload pages artifact
       uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 #v5.0.0
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,33 +12,34 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
-    - name: Set up Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
+    - name: Set up uv
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b #v8.1.0
       with:
-        python-version: "3.13"
+        enable-cache: true
+
+    - name: Set up Python
+      run: uv python install 3.13
 
     - name: Verify tag matches package version
       run: |
         TAG="${GITHUB_REF_NAME#v}"
-        PKG=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+        PKG=$(uv run --no-project python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
         if [ "$TAG" != "$PKG" ]; then
           echo "Tag $GITHUB_REF_NAME does not match package version $PKG"
           exit 1
         fi
 
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install .[dev,publish]
+      run: uv sync --extra dev --extra publish --python 3.13
 
     - name: Run unit tests
-      run: pytest
+      run: uv run pytest
 
     - name: Build package
-      run: python -m build
+      run: uv run python -m build
 
     - name: Verify package
-      run: python -m twine check dist/*
+      run: uv run python -m twine check dist/*
 
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,10 @@ target/
 # pyenv
 .python-version
 
+# uv
+uv.lock
+.venv/
+
 # editor files
 *.swp
 .vscode

--- a/puz.py
+++ b/puz.py
@@ -1,8 +1,6 @@
 ﻿from __future__ import annotations  # for Python 3.9 and earlier
 
-import functools
 import importlib.metadata
-import operator
 import math
 import string
 import struct
@@ -1088,8 +1086,7 @@ def unshift(s: str, key: list[int]) -> str:
 
 def shuffle(s: str) -> str:
     mid = int(math.floor(len(s) / 2))
-    items = functools.reduce(operator.add, zip(s[mid:], s[:mid]))
-    return ''.join(items) + (s[-1] if len(s) % 2 else '')
+    return ''.join(a + b for a, b in zip(s[mid:], s[:mid])) + (s[-1] if len(s) % 2 else '')
 
 
 def unshuffle(s: str) -> str:

--- a/puz_viewer.py
+++ b/puz_viewer.py
@@ -1,5 +1,6 @@
 import argparse
 import html as html_lib
+import io
 import json
 import os
 import sys
@@ -570,7 +571,7 @@ def main() -> None:
             with open(outfile, 'w', encoding='utf-8') as fout:
                 fout.write(out)
         else:
-            if hasattr(sys.stdout, 'reconfigure'):
+            if isinstance(sys.stdout, io.TextIOWrapper):
                 sys.stdout.reconfigure(encoding='utf-8')
             sys.stdout.write(out)
         return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,11 +27,11 @@ maintainers = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-codeblocks", "pytest-cov", "pytest-flake8", "pyright"]
+dev = ["pytest", "pytest-codeblocks", "pytest-cov", "pyright", "ruff"]
 publish = ["build", "twine"]
 
 [tool.pytest.ini_options]
-addopts = "--codeblocks --flake8"
+addopts = "--codeblocks"
 testpaths = ["README.md", "*.py"]
 filterwarnings = ["ignore::DeprecationWarning"]
 
@@ -55,6 +55,10 @@ Issues = "https://github.com/alexdej/puzpy/issues"
 include = ["*.py"]
 pythonVersion = "3.9"
 typeCheckingMode = "standard"
+
+[tool.ruff]
+line-length = 127
+target-version = "py39"
 
 [build-system]
 requires = ["setuptools >= 77.0.3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,11 +27,11 @@ maintainers = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-codeblocks", "pytest-cov", "pytest-flake8", "pytest-mypy"]
+dev = ["pytest", "pytest-codeblocks", "pytest-cov", "pytest-flake8", "pyright"]
 publish = ["build", "twine"]
 
 [tool.pytest.ini_options]
-addopts = "--codeblocks --mypy --flake8"
+addopts = "--codeblocks --flake8"
 testpaths = ["README.md", "*.py"]
 filterwarnings = ["ignore::DeprecationWarning"]
 
@@ -51,10 +51,10 @@ py-modules = ["puz"]
 Repository = "https://github.com/alexdej/puzpy.git"
 Issues = "https://github.com/alexdej/puzpy/issues"
 
-[tool.mypy]
-files = ["*.py"]
-strict = true
-no_incremental = true
+[tool.pyright]
+include = ["*.py"]
+pythonVersion = "3.9"
+typeCheckingMode = "standard"
 
 [build-system]
 requires = ["setuptools >= 77.0.3"]


### PR DESCRIPTION
a few cleanup/modernization tasks here:

- switch to using uv in CI jobs
- replace mypy (and pytest-mypy) with pyright; faster, more modern
- replace flake8 (and pytest-flake8) with ruff; ditto.
- split out ruff and pyright from tests in CI runner.
- two small changes required to make pyright happy.