### PR TITLE
pin pytest <9.1 to avoid breaking change to pytest-codeblocks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,18 @@ maintainers = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-codeblocks", "pytest-cov", "pyright", "ruff"]
+dev = [
+    "pytest<9.1", 
+    "pytest-codeblocks", 
+    "pytest-cov",
+    "pyright", 
+    "ruff"
+]
 publish = ["build", "twine"]
 
 [tool.pytest.ini_options]
 addopts = "--codeblocks"
 testpaths = ["README.md", "*.py"]
-filterwarnings = ["ignore::DeprecationWarning"]
 
 [tool.coverage.run]
 source = ["puz"]


### PR DESCRIPTION
pytest 9.1 contains a breaking change that prevents loading of certain pytest extensions including pytest-codeblocks which this project uses. for now, just pin pytest to <9.1 to avoid it.