### PR TITLE
Fix Timer.save() injecting spurious LTIM section on read

### DIFF
--- a/puz.py
+++ b/puz.py
@@ -966,11 +966,13 @@ class Timer(PuzzleHelper):
 
     def __init__(self, puzzle: Puzzle) -> None:
         self.puzzle = puzzle
+        self._present = Extensions.Timer in self.puzzle.extensions
         timer_data = self.puzzle.extensions.get(Extensions.Timer, b'0,1')
         elapsed_str, status_str = timer_data.decode().split(',')
 
         self.elapsed_seconds = int(elapsed_str)
         self.status = TimerStatus(int(status_str))
+        self._loaded = (self.elapsed_seconds, self.status)
 
     def is_running(self) -> bool:
         return self.status == TimerStatus.Running
@@ -979,7 +981,8 @@ class Timer(PuzzleHelper):
         return self.status == TimerStatus.Stopped
 
     def save(self) -> None:
-        self.puzzle.extensions[Extensions.Timer] = f'{self.elapsed_seconds},{self.status}'.encode()
+        if self._present or (self.elapsed_seconds, self.status) != self._loaded:
+            self.puzzle.extensions[Extensions.Timer] = f'{self.elapsed_seconds},{self.status}'.encode()
 
 
 # helper functions for cksums and scrambling

--- a/tests.py
+++ b/tests.py
@@ -974,6 +974,28 @@ def test_timer_save_roundtrip() -> None:
     assert p.extensions[puz.Extensions.Timer] == b'42,1'
 
 
+def test_timer_read_only_does_not_inject_extension() -> None:
+    filename = 'testfiles/nyt_nov0596.puz'
+    with open(filename, 'rb') as fp:
+        orig = fp.read()
+    p = puz.read(filename)
+    assert puz.Extensions.Timer not in p.extensions
+    _ = p.timer().elapsed_seconds
+    new = p.tobytes()
+    assert puz.Extensions.Timer not in puz.load(new).extensions
+    assert orig == new, 'reading the timer broke the byte-exact round-trip'
+
+
+def test_timer_added_to_puzzle_without_one_is_saved() -> None:
+    p = _make_puzzle()
+    assert not p.has_timer() or puz.Extensions.Timer not in p.extensions
+    t = p.timer()
+    t.elapsed_seconds = 30
+    t.status = puz.TimerStatus.Running
+    p.tobytes()  # triggers save()
+    assert p.extensions[puz.Extensions.Timer] == b'30,0'
+
+
 def test_timer_stopped() -> None:
     p = _make_puzzle()
     p.extensions[puz.Extensions.Timer] = b'120,1'


### PR DESCRIPTION
`Timer.save()` persisted the `LTIM` extension unconditionally. Because `tobytes()` calls `save()` on every instantiated helper, simply *reading* the timer and then re-serializing added a timer section that wasn't in the original file:

```python
p = puz.read('nyt_nov0596.puz')   # file has GEXT, no LTIM
_ = p.timer().elapsed_seconds     # read-only peek, e.g. to display elapsed time
p.tobytes()                       # -> injects LTIM b'0,1', breaks byte-exact round-trip
```

This is the same class of bug as the already-fixed #53 ("Rebus.save() injects spurious RUSR extension on save"). `Rebus` and `Markup` guard their `save()` with `has_rebus()` / `has_markup()`; `Timer` (added in 0.5.0) had no equivalent guard.

It went unnoticed because `test_puzfile_roundtrip_with_helpers` only instantiates the Timer helper when `has_timer()` is already true, so it never exercises the "no timer, then touched" path.

## Fix

`Timer` now records whether the file carried an `LTIM` section and a snapshot of the loaded values, and `save()` only writes when the timer was present originally or the caller modified `elapsed_seconds` / `status`.

## Tests

- `test_timer_read_only_does_not_inject_extension`: reading the timer on a file without one leaves the bytes unchanged.
- `test_timer_added_to_puzzle_without_one_is_saved`: explicitly setting timer values on a puzzle that had none still writes `LTIM`.

All existing tests pass (113 total); no changes to public API or behavior for files that already contain a timer.